### PR TITLE
merging https://bugs.chromium.org/p/chromium/issues/detail?id=789612

### DIFF
--- a/chrome-bisect.py
+++ b/chrome-bisect.py
@@ -12,7 +12,7 @@ unzipping, and opening Chromium for you. After testing the specific revision,
 it will ask you whether it is good or bad before continuing the search.
 """
 
-__version__ = '1.04'
+__version__ = '1.05'
 
 # The base URL for stored build archives.
 CHROMIUM_BASE_URL = ('http://commondatastorage.googleapis.com'
@@ -155,6 +155,8 @@ class PathContext(object):
       self.archive_name = 'chrome-mac.zip'
       self._archive_extract_dir = 'chrome-mac'
     elif self.platform in ('win', 'win64'):
+      # Note: changed at revision 591483; see GetDownloadURL and GetLaunchPath
+      # below where these are patched.
       self.archive_name = 'chrome-win32.zip'
       self._archive_extract_dir = 'chrome-win32'
       self._binary_name = 'chrome.exe'
@@ -162,6 +164,8 @@ class PathContext(object):
       raise Exception('Invalid platform: %s' % self.platform)
 
     if self.platform in ('linux', 'linux64', 'linux-arm', 'chromeos'):
+      # Note: changed at revision 591483; see GetDownloadURL and GetLaunchPath
+      # below where these are patched.
       self.archive_name = 'chrome-linux.zip'
       self._archive_extract_dir = 'chrome-linux'
       if self.platform == 'linux':
@@ -209,8 +213,19 @@ class PathContext(object):
           self.GetASANBaseName(), revision)
     if str(revision) in self.githash_svn_dict:
       revision = self.githash_svn_dict[str(revision)]
+    archive_name = self.archive_name
+
+    # At revision 591483, the names of two of the archives changed
+    # due to: https://chromium-review.googlesource.com/#/q/1226086
+    # See: http://crbug.com/789612
+    if revision >= 591483:
+      if self.platform == 'chromeos':
+        archive_name = 'chrome-chromeos.zip'
+      elif self.platform in ('win', 'win64'):
+        archive_name = 'chrome-win.zip'
+
     return '%s/%s%s/%s' % (self.base_url, self._listing_platform_dir,
-                           revision, self.archive_name)
+                           revision, archive_name)
 
   def GetLastChangeURL(self):
     """Returns a URL to the LAST_CHANGE file."""
@@ -231,6 +246,16 @@ class PathContext(object):
       extract_dir = '%s-%d' % (self.GetASANBaseName(), revision)
     else:
       extract_dir = self._archive_extract_dir
+
+    # At revision 591483, the names of two of the archives changed
+    # due to: https://chromium-review.googlesource.com/#/q/1226086
+    # See: http://crbug.com/789612
+    if revision >= 591483:
+      if self.platform == 'chromeos':
+        extract_dir = 'chrome-chromeos'
+      elif self.platform in ('win', 'win64'):
+        extract_dir = 'chrome-win'
+
     return os.path.join(extract_dir, self._binary_name)
 
   def ParseDirectoryIndex(self, last_known_rev):
@@ -566,7 +591,7 @@ def RunRevision(context, revision, zip_file, profile, num_runs, command, args):
 
   # Hack: Some Chrome OS archives are missing some files; try to copy them
   # from the local directory.
-  if context.platform == 'chromeos':
+  if context.platform == 'chromeos' and revision < 591483:
     CopyMissingFileFromCurrentSource('third_party/icu/common/icudtl.dat',
                                      '%s/chrome-linux/icudtl.dat' % tempdir)
     CopyMissingFileFromCurrentSource('*out*/*/libminigbm.so',


### PR DESCRIPTION
https://chromium.googlesource.com/chromium/src.git/+/e84e40bb849917b308f747659af851c963a46655

Starting with revision 591483, the Chrome OS and Win archives
are named chrome-chromeos.zip instead of chrome-linux.zip,
and chrome-win.zip instead of chrome-win32.zip, respectively.